### PR TITLE
fix workflow security issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
 name: CI-Build
+permissions:
+  checks: write
+  pull-requests: write
 
 on:
   push:

--- a/.github/workflows/publish-release-drafter.yml
+++ b/.github/workflows/publish-release-drafter.yml
@@ -1,4 +1,5 @@
 name: Publish Release Drafter
+permissions: {}
 
 on:
   workflow_run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release-Build
+permissions: {}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
> If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write.
