### PR TITLE
update release-drafter

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,17 @@
+name: Auto Label
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  auto_label:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Autolabeler
+        uses: release-drafter/release-drafter/autolabeler@v7

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -5,12 +5,10 @@ on:
     types: [opened, reopened, synchronize]
 
 permissions:
-  contents: read
+  pull-requests: write
 
 jobs:
   auto_label:
-    permissions:
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Run Autolabeler

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
       - release/*
-  pull_request:
-    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 env:
@@ -15,19 +13,14 @@ env:
 
 permissions:
   contents: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
       - name: Configure Release Draft Settings
-        if: ${{ env.SKIP_DRAFTER != 'true' }}
         run: |
-          if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "pull_request_target" ]]; then
-            exit 0
-          fi
-
           if [[ "$GITHUB_REF_NAME" = release/* ]]; then
             RELEASE_VERSION="${GITHUB_REF_NAME#release/}"
             echo "DRAFTER_NAME=Next Release $RELEASE_VERSION 🛒" >> $GITHUB_ENV
@@ -35,12 +28,8 @@ jobs:
           fi
 
       - name: Run Release Drafter
-        if: ${{ env.SKIP_DRAFTER != 'true' }}
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@v7
         with:
           name: ${{ env.DRAFTER_NAME }}
           tag: ${{ env.DRAFTER_TAG }}
           commitish: ${{ github.ref }}
-          disable-releaser: ${{ contains(fromJSON('["pull_request", "pull_request_target"]'), github.event_name) }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
release-drafter@v7 release notes: https://github.com/release-drafter/release-drafter/pull/1475

- Autolabeler moved to a dedicated action
- `token` input replaces the need for `GITHUB_TOKEN` env variable