### PR TITLE
XIVY-18805 deflake create project integration test

### DIFF
--- a/ch.ivyteam.smart.core.tests.integration/test/ch/ivyteam/smart/core/copilot/CopilotIntegrationTest.java
+++ b/ch.ivyteam.smart.core.tests.integration/test/ch/ivyteam/smart/core/copilot/CopilotIntegrationTest.java
@@ -104,6 +104,6 @@ public class CopilotIntegrationTest {
     var spans = aspireApi.spansOfResource(resource);
     var tokenUsage = TelemetryUtils.tokenUsage(spans);
     assertThat(tokenUsage.input()).isLessThan(150000);
-    assertThat(tokenUsage.output()).isLessThan(5000);
+    assertThat(tokenUsage.output()).isLessThan(10000);
   }
 }


### PR DESCRIPTION
Increase expected output token usage limit from 5'000 to 10'000.
