### PR TITLE
suppress warnings

### DIFF
--- a/ch.ivyteam.smart.core/src/ch/ivyteam/smart/core/transport/JavaxHttpServletStreamableServerTransportProvider.java
+++ b/ch.ivyteam.smart.core/src/ch/ivyteam/smart/core/transport/JavaxHttpServletStreamableServerTransportProvider.java
@@ -58,6 +58,7 @@ import reactor.core.publisher.Mono;
  * @see McpStreamableServerTransportProvider
  * @see HttpServlet
  */
+@SuppressWarnings("all")
 @WebServlet(asyncSupported = true)
 public class JavaxHttpServletStreamableServerTransportProvider extends HttpServlet
     implements McpStreamableServerTransportProvider {


### PR DESCRIPTION
Suppress warnings in `JavaxHttpServletStreamableServerTransportProvider` as it's copied over from `io.modelcontextprotocol`.
